### PR TITLE
Update wlanscan.ps1

### DIFF
--- a/wlanscan.ps1
+++ b/wlanscan.ps1
@@ -44,7 +44,7 @@ function CloneEntry
 }
 
 # Windows Vista/2008/7
-if  ((gwmi win32_operatingsystem).Version.Split(".")[0] -gt 6) {
+if  (6 -gt (gwmi win32_operatingsystem).Version.Split(".")[0]) {
 	throw "This script works on Windows Vista or higher."
 }
 if ((gsv "wlansvc").Status -ne "Running" ) {


### PR DESCRIPTION
Fixed version check casting 10 as string by reversing the test causing a cast to int